### PR TITLE
Add MMLU, GSM8K and Math500 evaluation tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ python main.py --model hf-causal-experimental --model_args pretrained=$MODEL_ADD
 --ptq_param_path "./search_result/FPQ_config_llama/W4A4E4_search_round3_search_intervals(0.01,1.2,100).pt"
 ```
 
+To evaluate on the MMLU, GSM8K and MATH500 benchmarks:
+
+```bash
+python main.py --model hf-causal-experimental --model_args pretrained=$MODEL_ADDR,use_accelerate=True \
+--tasks mmlu,gsm8k,math500 --device cuda --batch_size auto --only_eval \
+--ptq_param_path <path_to_quant_params>
+```
+
 ## PTQ Result
 Below is the results in LLaMA-7B and LLaMA-13B with six commonsense reasoning datasets.
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -49,6 +49,8 @@ from . import truthfulqa
 from . import blimp
 from . import asdiv
 from . import gsm8k
+from . import mmlu
+from . import math500
 from . import storycloze
 from . import toxigen
 from . import crowspairs
@@ -175,6 +177,8 @@ TASK_REGISTRY = {
     "math_precalc": hendrycks_math.MathPrecalculus,
     "math_asdiv": asdiv.Asdiv,
     "gsm8k": gsm8k.GradeSchoolMath8K,
+    "mmlu": mmlu.MMLU,
+    "math500": math500.Math500,
     # arithmetic
     "arithmetic_2da": arithmetic.Arithmetic2DPlus,
     "arithmetic_2ds": arithmetic.Arithmetic2DMinus,

--- a/lm_eval/tasks/math500.py
+++ b/lm_eval/tasks/math500.py
@@ -1,0 +1,42 @@
+from lm_eval.base import Task, rf
+from lm_eval.metrics import mean
+
+
+class Math500(Task):
+    """Subset of mathematics problems with 500 evaluation questions."""
+
+    VERSION = 0
+    DATASET_PATH = "math500"
+    DATASET_NAME = "main"
+
+    def has_training_docs(self):
+        return False
+
+    def has_validation_docs(self):
+        return False
+
+    def has_test_docs(self):
+        return True
+
+    def test_docs(self):
+        return self.dataset["test"]
+
+    def doc_to_text(self, doc):
+        return "Problem: " + doc["problem"] + "\nAnswer:"
+
+    def doc_to_target(self, doc):
+        return " " + doc["solution"]
+
+    def construct_requests(self, doc, ctx):
+        return rf.greedy_until(ctx, {"until": ["\n"]})
+
+    def process_results(self, doc, results):
+        pred = results[0].strip()
+        gold = doc["solution"].strip()
+        return {"acc": int(pred == gold)}
+
+    def aggregation(self):
+        return {"acc": mean}
+
+    def higher_is_better(self):
+        return {"acc": True}

--- a/lm_eval/tasks/mmlu.py
+++ b/lm_eval/tasks/mmlu.py
@@ -1,0 +1,9 @@
+from .hendrycks_test import GeneralHendrycksTest
+
+class MMLU(GeneralHendrycksTest):
+    """Massive Multitask Language Understanding (all subjects)."""
+
+    def __init__(self):
+        # "all" is the configuration on the HuggingFace dataset that
+        # contains the full evaluation set across subjects.
+        super().__init__("all")


### PR DESCRIPTION
## Summary
- add `mmlu` and `math500` tasks
- register them in the task registry
- document how to run evaluation on the new tasks

## Testing
- `pytest -q` *(fails: ImportError while importing lm_eval.tasks.hendrycks_test)*

------
https://chatgpt.com/codex/tasks/task_e_685aa92dd24c833295814d5d2c527b0d